### PR TITLE
Remove limitation note on biome changes in worlds with modified height ranges

### DIFF
--- a/docs/usage/worldedit_app.md
+++ b/docs/usage/worldedit_app.md
@@ -51,5 +51,4 @@ You may have to press "Show All Assets" to see the file you need. Once downloade
 
 ## Limitations
 
-- Changing biomes may not work properly in worlds with a modded height range.
 - Marketplace maps are encrypted, so they can't be modified.


### PR DESCRIPTION
Worlds with modified height ranges are fully supported and I have thoroughly tested it to ensure that is the case.