### PR TITLE
update `Usage > Bedrock World Editor` page

### DIFF
--- a/docs/usage/worldedit_app.md
+++ b/docs/usage/worldedit_app.md
@@ -2,9 +2,13 @@
 
 !!! Important
 
-    as of writing the app supports Windows, Linux and MacOS.
+    As of writing, the app supports Windows, Linux and macOS.
 
-Bedrock World Editor app is an NBT editor created by [8Crafter](https://github.com/8Crafter-Studios). Apart from NBT editing, it comes with WorldEdit support that lets you process worlds in ways you can't with just the addon.
+!!! attention "Help Wanted"
+
+    Support for mobile platforms is in development. **Your** contribution can help it arrive sooner, visit [this page](https://github.com/8Crafter-Studios/Bedrock-World-Editor/milestone/1) for more information.
+
+[Bedrock World Editor](https://github.com/8Crafter-Studios/Bedrock-World-Editor) is an NBT editor created by [8Crafter](https://github.com/8Crafter-Studios). Apart from NBT editing, it comes with WorldEdit support that lets you process worlds in ways you can't with just the addon.
 
 1. Exporting structures and using them in other worlds
 2. Changing biomes
@@ -19,11 +23,13 @@ Bedrock World Editor app is an NBT editor created by [8Crafter](https://github.c
 
 First you go the app's GitHub page [here](https://github.com/8Crafter-Studios/Bedrock-World-Editor). In this page you'll find a "Releases" section. There you will find all released versions of the app. Go for the latest version. Under it you'll see a list of "Assets". Download the one made for your device.
 
-- Windows: .exe
-- MacOS: .dmg
-- Linux: .deb / .rpm
+- Windows: `.exe`
+- macOS: `.dmg`
+- Linux: `.deb` / `.rpm`
 
-You may have to press "Show All Assets" to see the file you need. Once downloaded, installation will depend on your system. For Windows it's as simple as running the setup executable file and going through any needed steps to get it up and running.
+You may have to press "Show All Assets" to see the file you need. Once downloaded, installation will depend on your system. For Windows, it's as simple as running the setup executable file and going through any needed steps to get it up and running.
+
+Alternatively, [this link](https://github.com/8Crafter-Studios/Bedrock-World-Editor/releases/latest) will always lead you to the latest release of Bedrock World Editor.
 
 ## Usage
 
@@ -52,3 +58,7 @@ You may have to press "Show All Assets" to see the file you need. Once downloade
 ## Limitations
 
 - Marketplace maps are encrypted, so they can't be modified.
+
+## Additional Information
+
+The [Bedrock World Editor wiki](https://wiki.8crafter.com/bwe) also has a page on this integration [here](https://wiki.8crafter.com/bwe/integrations/worldedit-bedrock).


### PR DESCRIPTION
A few changes here:
- Added a "Help Wanted" callout for mobile support (I'd like your thoughts whether using [this link](https://github.com/8Crafter-Studios/Bedrock-World-Editor/milestone/1) is fine with you @8Crafter)
- Changed the formatting of the file extensions to code blocks (for example: `.exe`)
- Added a link that navigates to the [latest release](https://github.com/8Crafter-Studios/Bedrock-World-Editor/releases/latest) of Bedrock World Editor at the bottom of the installation section
- Added a link to the [sibling page](https://wiki.8crafter.com/bwe/integrations/worldedit-bedrock) on 8Crafter's wiki
- [macOS is spelt with a lowercase "m" when referring to it generically
](https://support.apple.com/en-au/guide/applestyleguide/apsg72b28652/1.0/web/1.0#apd246e83209)
<img width="737" height="746" alt="New introduction section" src="https://github.com/user-attachments/assets/205a8895-2d09-45f1-b876-7cbd3b882c03" />
